### PR TITLE
Improve documentation and allow local runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,11 +52,18 @@ ready to deploy on docker containers in Amazon EC2.
 
 ## Your first server
 
+Klue uses [redis](https://redis.io/topics/quickstart#installing-redis) to schedule asynchronous tasks,
+if you are on OSX, simply install it via homebrew -- ```brew install redis```, or follow the simple instructions
+on their quickstart for a custom installation.
+
+We also recommend using [pipenv](http://docs.python-guide.org/en/latest/dev/virtualenvs/) to install
+and manage pyhton dependencies.
+
 Install klue-microservice:
 
 ```
-pip install klue-microservice
-pip install klue-microservice-deploy
+pipenv install klue-microservice
+pipenv install klue-microservice-deploy
 ```
 
 A REST api microservice built with klue-microservice has a directory tree
@@ -175,13 +182,13 @@ deploy_pipeline --push --deploy
 ### Installing
 
 ```
-pip install klue-microservice
+pipenv install klue-microservice
 ```
 
 Optionally, to deploy to Amazon:
 
 ```
-pip install klue-microservice-deploy
+pipenv install klue-microservice-deploy
 ```
 
 

--- a/klue_microservice/config.py
+++ b/klue_microservice/config.py
@@ -29,7 +29,8 @@ class KlueConfig(object):
             os.path.join(os.path.dirname(sys.argv[0]), 'klue-config.yaml'),
             '/klue/klue-config.yaml',
             os.path.join(os.path.dirname(sys.argv[0]), 'test/klue-config.yaml'),
-            os.path.join(os.path.dirname(os.path.abspath(__file__)), '..', 'klue-config.yaml')
+            os.path.join(os.path.dirname(os.path.abspath(__file__)), '..', 'klue-config.yaml'),
+            os.path.join(os.getcwd(), 'klue-config.yaml')
         ]
 
         if path:


### PR DESCRIPTION
The commits bring a fix and a few documentation improvements,

- Search for klue-config.yaml in current working directory
- Use pipenv for installation/dependency management
- Make redis requirement explicit

After these changes, its possible to run klue-microservices locally, with minimal dependencies and docker.